### PR TITLE
Write tests for node_qemu_handler.py

### DIFF
--- a/plugins/module_utils/proxmox/handlers/node_qemu_handler.py
+++ b/plugins/module_utils/proxmox/handlers/node_qemu_handler.py
@@ -32,13 +32,13 @@ class NodeQemuHandler(BaseHandler):
             return AnsibleResult(status=True)
 
         request = self._client_class(f"{self._path}/{self._resource.vmid}")
-        if self._resource.destroy_unreferenced_disks is not None:
+        if self._resource.destroy_unreferenced_disks:
             request.add_option("destroy-unreferenced-disks", self._resource.destroy_unreferenced_disks)
 
-        if self._resource.purge is not None:
+        if self._resource.purge:
             request.add_option("purge", self._resource.purge)
 
-        if self._resource.skiplock is not None:
+        if self._resource.skiplock:
             request.add_option("skiplock", self._resource.skiplock)
 
         request.delete()

--- a/plugins/module_utils/proxmox/resources/node/qemu/__init__.py
+++ b/plugins/module_utils/proxmox/resources/node/qemu/__init__.py
@@ -15,7 +15,7 @@ class Qemu(Resource):
         data = self._normalize_proxmox_format(raw)
         vmid = data.get("vmid", None)
         self.node: Optional[str] = node
-        self.vmid: Optional[str] = str(vmid) if vmid else None
+        self.vmid: Optional[str] = str(vmid) if vmid is not None else None
 
         # Create options
         self.acpi: Optional[str] = data.get("acpi", None)
@@ -48,7 +48,7 @@ class Qemu(Resource):
         self.hostpci: Optional[str] = data.get("hostpci", None)
         self.hookscript: Optional[str] = data.get("hookscript", None)
         self.hugepages: Optional[str] = data.get("hugepages", None)
-        self.ide: Optional[str] = load_objs_from_list(data.get("ide", []), IDEStorage)
+        self.ide: List[IDEStorage] = load_objs_from_list(data.get("ide", []), IDEStorage)
         self.import_working_storage: Optional[str] = data.get("import-working-storage", None)
         self.ipconfig: Optional[str] = data.get("ipconfig", None)
         self.ivshmem: Optional[str] = data.get("ivshmem", None)
@@ -73,8 +73,8 @@ class Qemu(Resource):
         self.protection: Optional[str] = data.get("protection", None)
         self.reboot: Optional[str] = data.get("reboot", None)
         self.rng0: Optional[str] = data.get("rng0", None)
-        self.sata: Optional[str] = load_objs_from_list(data.get("sata", []), SATAStorage)
-        self.scsi: Optional[str] = load_objs_from_list(data.get("scsi", []), SCSIStorage)
+        self.sata: list[SATAStorage] = load_objs_from_list(data.get("sata", []), SATAStorage)
+        self.scsi: list[SCSIStorage] = load_objs_from_list(data.get("scsi", []), SCSIStorage)
         self.scsihw: Optional[str] = data.get("scsihw", None)
         self.searchdomain: Optional[str] = data.get("searchdomain", None)
         self.serial: Optional[str] = data.get("serial", None)
@@ -97,15 +97,17 @@ class Qemu(Resource):
         self.usb: Optional[str] = data.get("usb", None)
         self.vcpus: Optional[str] = data.get("vcpus", None)
         self.vga: Optional[str] = data.get("vga", None)
-        self.virtio: Optional[str] = load_objs_from_list(data.get("virtio", []), VIRTIOStorage)
+        self.virtio: list[VIRTIOStorage] = load_objs_from_list(data.get("virtio", []), VIRTIOStorage)
         self.vmgenid: Optional[str] = data.get("vmgenid", None)
         self.vmstatestorage: Optional[str] = data.get("vmstatestorage", None)
         self.watchdog: Optional[str] = data.get("watchdog", None)
 
         # Delete options
-        self.destroy_unreferenced_disks: Optional[str] = data.get("destroy-unreferenced-disks", None)
-        self.purge: Optional[str] = data.get("purge", None)
-        self.skiplock: Optional[str] = data.get("skiplock", None)
+        self.destroy_unreferenced_disks: bool = data.get(
+            "destroy-unreferenced-disks", data.get("destroy_unreferenced_disks", False)
+        )
+        self.purge: bool = data.get("purge", False)
+        self.skiplock: bool = data.get("skiplock", False)
 
         self._mappings.update(
             {

--- a/plugins/tests/module_utils/proxmox/handlers/test_node_qemu_handler.py
+++ b/plugins/tests/module_utils/proxmox/handlers/test_node_qemu_handler.py
@@ -1,0 +1,224 @@
+import pytest
+from typing import Iterable
+from module_utils.proxmox.handlers.node_qemu_handler import NodeQemuHandler
+from ..utils import create_client, Response
+
+
+@pytest.mark.parametrize(
+    "input_data,responses,changed",
+    [
+        pytest.param(
+            {
+                "node": "testprox",
+                "vmid": "101",
+                "name": "testvm",
+                "cores": 4,
+                "memory": 4096,
+                "tags": "test",
+                "pool": "test",
+                "net": [
+                    {"idx": 0, "model": "virtio", "bridge": "vmbr0", "tag": 101},
+                    {"idx": 1, "model": "virtio", "bridge": "vmbr0", "tag": 102},
+                    {"idx": 2, "model": "virtio", "bridge": "vmbr0", "tag": 103},
+                ],
+                "scsi": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "ide": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "sata": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "virtio": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+            },
+            [
+                Response(
+                    command=["/usr/bin/pvesh", "get", "nodes/testprox/qemu/101/config", "--output-format=json"],
+                    return_code=0,
+                    stdout=b'{"vmid": "101", "name": "testvm", "cores": 4, "memory": 4096, "tags": "test", "pool": "test", "net0": "virtio,bridge=vmbr0,tag=101", "net1": "virtio,bridge=vmbr0,tag=102", "net2": "virtio,bridge=vmbr0,tag=103", "scsi0": "local-lvm:1,cache=writeback", "ide0": "local-lvm:1,cache=writeback", "sata0": "local-lvm:1,cache=writeback", "virtio0": "local-lvm:1,cache=writeback"}',
+                    stderr=b'',
+                ),
+            ],
+            False,
+            id="not-modification",
+        ),
+        pytest.param(
+            {
+                "node": "testprox",
+                "vmid": "101",
+                "name": "testvm",
+                "cores": 4,
+                "memory": 8192,
+                "tags": "test",
+                "pool": "test",
+                "net": [
+                    {"idx": 0, "model": "virtio", "bridge": "vmbr0", "tag": 101},
+                    {"idx": 1, "model": "virtio", "bridge": "vmbr0", "tag": 102},
+                    {"idx": 2, "model": "virtio", "bridge": "vmbr0", "tag": 103},
+                ],
+                "scsi": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "ide": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "sata": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "virtio": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+            },
+            [
+                Response(
+                    command=["/usr/bin/pvesh", "get", "nodes/testprox/qemu/101/config", "--output-format=json"],
+                    return_code=0,
+                    stdout=b'{"vmid": "101", "name": "testvm", "cores": 4, "memory": 4096, "tags": "test", "pool": "test", "net0": "virtio,bridge=vmbr0,tag=101", "net1": "virtio,bridge=vmbr0,tag=102", "net2": "virtio,bridge=vmbr0,tag=103", "scsi0": "local-lvm:1,cache=writeback", "ide0": "local-lvm:1,cache=writeback", "sata0": "local-lvm:1,cache=writeback", "virtio0": "local-lvm:1,cache=writeback"}',
+                    stderr=b'',
+                ),
+                Response(
+                    command=["/usr/bin/pvesh", "set", "nodes/testprox/qemu/101/config", "--memory=8192", "--output-format=json"],
+                    return_code=0,
+                    stdout=b'',
+                    stderr=b'',
+                ),
+            ],
+            True,
+            id="modified",
+        )
+    ]
+)
+def test_node_qemu_handler_modify(input_data: dict, responses: Iterable[Response], changed: bool) -> None:
+    client = create_client(responses)
+    handler = NodeQemuHandler(client, input_data)
+    ansible_result = handler.modify(check=False)
+    assert ansible_result.status == changed
+    assert client.responses.empty()
+
+
+@pytest.mark.parametrize(
+    "input_data,responses,changed",
+    [
+        pytest.param(
+            {
+                "node": "testprox",
+                "vmid": "101",
+                "name": "testvm",
+                "cores": 4,
+                "memory": 4096,
+                "tags": "test",
+                "pool": "test",
+                "net": [
+                    {"idx": 0, "model": "virtio", "bridge": "vmbr0", "tag": 101},
+                    {"idx": 1, "model": "virtio", "bridge": "vmbr0", "tag": 102},
+                    {"idx": 2, "model": "virtio", "bridge": "vmbr0", "tag": 103},
+                ],
+                "scsi": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "ide": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "sata": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+                "virtio": [
+                    {"idx": 0, "storage": "local-lvm", "size": 1, "cache": "writeback"},
+                ],
+            },
+            [
+                Response(
+                    command=["/usr/bin/pvesh", "create", "nodes/testprox/qemu", "--vmid=101", "--name=testvm", "--cores=4", "--memory=4096", "--tags=test", "--pool=test", "--net0=virtio,bridge=vmbr0,tag=101", "--net1=virtio,bridge=vmbr0,tag=102", "--net2=virtio,bridge=vmbr0,tag=103", "--scsi0=local-lvm:1,cache=writeback", "--ide0=local-lvm:1,cache=writeback", "--sata0=local-lvm:1,cache=writeback", "--virtio0=local-lvm:1,cache=writeback", "--output-format=json"],
+                    return_code=0,
+                    stdout=b'',
+                    stderr=b'',
+                ),
+            ],
+            True,
+            id="created",
+        ),
+    ]
+)
+def test_node_qemu_handler_create(input_data: dict, responses: Iterable[Response], changed: bool) -> None:
+    client = create_client(responses)
+    handler = NodeQemuHandler(client, input_data)
+    ansible_result = handler.create(check=False)
+    assert ansible_result.status == changed
+    assert client.responses.empty()
+
+
+@pytest.mark.parametrize(
+    "input_data,responses,changed",
+    [
+        pytest.param(
+            {
+                "node": "testprox",
+                "vmid": "101",
+                "destroy_unreferenced_disks": True,
+                "purge": True,
+                "skiplock": True,
+            },
+            [
+                Response(
+                    command=["/usr/bin/pvesh", "delete", "nodes/testprox/qemu/101", "--destroy-unreferenced-disks=True", "--purge=True", "--skiplock=True", "--output-format=json"],
+                    return_code=0,
+                    stdout=b'',
+                    stderr=b'',
+                ),
+            ],
+            True,
+            id="existing-resource",
+        ),
+    ]
+)
+def test_node_qemu_handler_delete(input_data: dict, responses: Iterable[Response], changed: bool) -> None:
+    client = create_client(responses)
+    handler = NodeQemuHandler(client, input_data)
+    ansible_result = handler.remove(check=False)
+    assert ansible_result.status == changed
+    assert client.responses.empty()
+
+
+def test_node_qemu_handler_lookup() -> None:
+    responses = [
+        Response(
+            command=["/usr/bin/pvesh", "get", "nodes/testprox/qemu/101/config", "--output-format=json"],
+            return_code=0,
+            stdout=b'{"vmid": "101", "name": "testvm", "cores": 4, "memory": 4096, "tags": "test", "pool": "test", "net0": "virtio,bridge=vmbr0,tag=101", "net1": "virtio,bridge=vmbr0,tag=102", "net2": "virtio,bridge=vmbr0,tag=103", "scsi0": "local-lvm:1,cache=writeback", "ide0": "local-lvm:1,cache=writeback", "sata0": "local-lvm:1,cache=writeback", "virtio0": "local-lvm:1,cache=writeback"}',
+            stderr=b'',
+        ),
+    ]
+    client = create_client(responses)
+    handler = NodeQemuHandler(client, {"node": "testprox", "vmid": "101"})
+    result = handler.lookup()
+    assert result.vmid == "101"
+    assert result.name == "testvm"
+    assert result.cores == 4
+    assert result.memory == 4096
+    assert result.tags == "test"
+    assert result.pool == "test"
+    assert result.net[0].model == "virtio"
+    assert result.net[0].bridge == "vmbr0"
+    assert result.net[0].tag == 101
+    assert result.net[1].model == "virtio"
+    assert result.net[1].bridge == "vmbr0"
+    assert result.net[1].tag == 102
+    assert result.net[2].model == "virtio"
+    assert result.net[2].bridge == "vmbr0"
+    assert result.net[2].tag == 103
+    assert result.scsi[0].storage == "local-lvm"
+    assert result.scsi[0].size == 1
+    assert result.scsi[0].cache == "writeback"
+    assert result.ide[0].storage == "local-lvm"
+    assert result.ide[0].size == 1
+    assert result.ide[0].cache == "writeback"
+    assert result.sata[0].storage == "local-lvm"
+    assert result.sata[0].size == 1
+    assert result.sata[0].cache == "writeback"
+    assert result.virtio[0].storage == "local-lvm"
+    assert result.virtio[0].size == 1
+    assert result.virtio[0].cache == "writeback"
+    assert client.responses.empty()


### PR DESCRIPTION
Add tests for `NodeQemuHandler` class in `plugins/tests/module_utils/proxmox/handlers/test_node_qemu_handler.py`.

* Add import statements for `pytest`, `Iterable`, `NodeQemuHandler`, `create_client`, and `Response`.
* Add `test_node_qemu_handler_modify` function to test the `modify` method of `NodeQemuHandler`.
* Add `test_node_qemu_handler_create` function to test the `create` method of `NodeQemuHandler`.
* Add `test_node_qemu_handler_delete` function to test the `remove` method of `NodeQemuHandler`.
* Add `test_node_qemu_handler_lookup` function to test the `lookup` method of `NodeQemuHandler`.

