### PR TITLE
Add GitHub Actions workflow to run tox -e pytest

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -1,0 +1,29 @@
+name: Tox Pytest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          pip install tox
+
+      - name: Run tests
+        run: tox -e pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ flake8
 mypy
 radon
 tox
+pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
-
 [tox]
-envlist = build,flake8,format,mypy
+envlist = build,flake8,format,mypy,pytest
 tox_files_path = {env:TOX_FILES_PATH:"tox_files"}
 
 [testenv] 


### PR DESCRIPTION
Add GitHub Actions workflow to test code using `tox -e pytest`.

* Create a new workflow file `.github/workflows/tox-pytest.yml` to run tests on `push` and `pull_request` events to the `main` branch.
* Add a job that runs on `ubuntu-latest`, checks out the repository, sets up Python 3.11, installs dependencies, and runs `tox -e pytest`.
* Modify `tox.ini` to include `pytest` in the `envlist`.
* Add `pytest` to the `requirements-test.txt` file.

