### PR TITLE
Add unit tests for pool_handler.py

### DIFF
--- a/plugins/tests/module_utils/proxmox/handlers/test_pool_handler.py
+++ b/plugins/tests/module_utils/proxmox/handlers/test_pool_handler.py
@@ -109,3 +109,20 @@ def test_pool_handler_delete(input_data: dict, responses: list[Response], change
     ansible_result = handler.remove(check=False)
     assert ansible_result.status == changed
     assert client.responses.empty()
+
+
+def test_pool_handler_lookup() -> None:
+    responses = [
+        Response(
+            command=["/usr/bin/pvesh", "get", "pools", "--poolid=testpool", "--output-format=json"],
+            return_code=0,
+            stdout=b'[{"poolid": "testpool", "comment": "Test pool"}]',
+            stderr=b'',
+        ),
+    ]
+    client = create_client(responses)
+    handler = PoolHandler(client, {"poolid": "testpool"})
+    result = handler.lookup()
+    assert result.poolid == "testpool"
+    assert result.comment == "Test pool"
+    assert client.responses.empty()


### PR DESCRIPTION
Add unit test for the `lookup` method in `PoolHandler` class.

* Add `test_pool_handler_lookup` function to test the `lookup` method.
* Verify that the `lookup` method returns the correct `Pool` object.
* Ensure the mock client responses are correctly set up for the `lookup` test.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Margays/ansible-proxmox/pull/13?shareId=82d0f950-bd5c-4b46-8836-d6d943e2c085).